### PR TITLE
Fix the issue with Widget::getConfig()

### DIFF
--- a/Widget.php
+++ b/Widget.php
@@ -122,7 +122,7 @@ class Widget extends \yii\base\Widget
      */
     public function getConfig($widget)
     {
-        $module = Config::getModule($this->moduleName);
+        $module = \Yii::$app->getModule($this->moduleName);
         return isset($module->$widget) ? $module->$widget : [];
     }
 


### PR DESCRIPTION
This change breaks the module. Throwing the exception ```Call to undefined method kartik\base\Config::getModule()```. Should use ```\Yii::$app->getModule()```.