### PR TITLE
Remove deprecated jQuery method usage in VK plugin

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,12 @@
 Change Log: `yii2-social`
 =========================
 
+## Version 1.3.6
+
+**Date:** 31-Oct-2019
+
+- (bug #78) Fix deprecated usage of jQuery method `load()` for VK plugin.
+
 ## Version 1.3.5
 
 **Date:** 21-Sep-2018

--- a/src/VKPlugin.php
+++ b/src/VKPlugin.php
@@ -207,7 +207,7 @@ class VKPlugin extends Widget
 if (window.VK && $check) {
     $call;
 } else {
-    \$('#$scriptId').load(function() {
+    \$('#$scriptId').on('load', function() {
         $call;
     });
 }


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-social/blob/master/CHANGE.md)):

- fix event listener attachment using `on('load', ...)` instead of deprecated usage `load(...)` for VK share plugin:

Note: This API has been removed in jQuery 3.0; please use .on( "load", handler ) instead of .load( handler ) and .trigger( "load" ) instead of .load().
(https://api.jquery.com/load-event/#load-handler)

## Related Issues
Fixes #78 